### PR TITLE
Sf/logging: Fix Issue #17 / More Flexible logging

### DIFF
--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -4,7 +4,7 @@ CPP  = g++.exe
 CC   = gcc.exe
 WINDRES = windres.exe
 
-CFLAGS = -O3 -DBEM -DVERSION=\"Win32\"
+CFLAGS = -O3 -Wall -DBEM -DVERSION=\"Win32\"
 
 OBJ = \
     6502.o \

--- a/src/b-em.h
+++ b/src/b-em.h
@@ -40,6 +40,8 @@ extern void bem_error(const char *s);
 extern void bem_errorf(const char *fmt, ...) printflike;
 extern void bem_warn(const char *s);
 extern void bem_warnf(const char *fmt, ...) printflike;
+extern void bem_info(const char *s);
+extern void bem_infof(const char *fmt, ...) printflike;
 extern void win_log_msgbox(const char *level, const char *s);
 
 // If debugging is enabled a real pair of functions will be available

--- a/src/b-em.h
+++ b/src/b-em.h
@@ -34,10 +34,13 @@ void setejecttext(int drive, char *fn);
 #define printflike
 #endif
 
-extern void bem_error(char *s);
+extern void log_open(void);
+extern void log_close(void);
+extern void bem_error(const char *s);
 extern void bem_errorf(const char *fmt, ...) printflike;
 extern void bem_warn(const char *s);
 extern void bem_warnf(const char *fmt, ...) printflike;
+extern void win_log_msgbox(const char *level, const char *s);
 
 // If debugging is enabled a real pair of functions will be available
 // to log debug messages.  if debug is disabled we use a static inline
@@ -47,14 +50,10 @@ extern void bem_warnf(const char *fmt, ...) printflike;
 #ifdef _DEBUG
 extern void bem_debug(const char *s);
 extern void bem_debugf(const char *format, ...) printflike;
-extern void debug_open(void);
-extern void debug_close(void);
 #else
 static inline void bem_debug(const char *s) {}
 static inline void bem_debugf(const char *format, ...) printflike;
 static inline void bem_debugf(const char *format, ...) {}
-static inline void debug_open(void) {}
-static inline void debug_close(void) {}
 #endif
 
 extern char exedir[512];

--- a/src/compat_wrappers.c
+++ b/src/compat_wrappers.c
@@ -40,19 +40,6 @@ x_fopen(const char *path, const char *mode)
 #include <errno.h>
 
 int
-asprintf(char **ret, const char *fmt, ...)
-{
-	va_list	ap;
-	int	n;
-
-	va_start(ap, fmt);
-	n = vasprintf(ret, fmt, ap);
-	va_end(ap);
-
-	return (n);
-}
-
-int
 vasprintf(char **ret, const char *fmt, va_list ap)
 {
 	int	 n;
@@ -81,6 +68,20 @@ error:
 	*ret = NULL;
 	return (-1);
 }
+
+int
+asprintf(char **ret, const char *fmt, ...)
+{
+	va_list	ap;
+	int	n;
+
+	va_start(ap, fmt);
+	n = vasprintf(ret, fmt, ap);
+	va_end(ap);
+
+	return (n);
+}
+
 #endif
 
 #ifndef HAVE_STPCPY

--- a/src/disc.c
+++ b/src/disc.c
@@ -63,9 +63,9 @@ void disc_load(int drive, char *fn)
         setejecttext(drive, "");
         if (!fn) return;
         p = get_extension(fn);
-        if (!p) return;
+        if (!p || !*p) return;
         setejecttext(drive, fn);
-        bem_debugf("Loading :%i %s %s\n", drive, fn,p);
+        bem_infof("disc: Loading %i %s %s\n", drive, fn, p);
         while (loaders[c].ext)
         {
                 if (!strcasecmp(p, loaders[c].ext))

--- a/src/fdi2raw.c
+++ b/src/fdi2raw.c
@@ -1311,7 +1311,7 @@ static int handle_sectors_described_track (FDI *fdi)
 {
 	uae_u8 *start_src = fdi->track_src;
 #ifdef _DEBUG
-	int oldout;
+	int oldout = 0;
 #endif
 	fdi->encoding_type = *fdi->track_src++;
 	fdi->index_offset = get_u32(fdi->track_src);
@@ -1328,7 +1328,7 @@ static int handle_sectors_described_track (FDI *fdi)
 		oldout = fdi->out;
 #endif
 		if (fdi->out < 0 || fdi->err) {
-			bem_debugf("\nin %ld bytes, out %d bits\n", fdi->track_src - fdi->track_src_buffer, fdi->out);
+		        bem_debugf("\nin %ld bytes, out %d bits\n", (long)(fdi->track_src - fdi->track_src_buffer), fdi->out);
 			return -1;
 		}
 		if (fdi->track_src - fdi->track_src_buffer >= fdi->track_src_len) {

--- a/src/linux.c
+++ b/src/linux.c
@@ -50,11 +50,6 @@ void updatewindow()
 {
 }
 
-void bem_error(char *s)
-{
-        allegro_message(s);
-}
-
 void setquit()
 {
         quited=1;
@@ -67,7 +62,7 @@ int main(int argc, char *argv[])
 
         if (allegro_init())
         {
-                printf("Failed to initialise Allegro!");
+	        fputs("Failed to initialise Allegro!\n", stderr);
                 exit(-1);
         }
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -2,81 +2,153 @@
 
 #include "b-em.h"
 
+#include <allegro.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <time.h>
+
+#define LOG_DEST_FILE   0x01
+#define LOG_DEST_STDERR 0x02
+#define LOG_DEST_MSGBOX 0x04
+
+#define LOG_DEBUG_MASK  0x000f
+#define LOG_DEBUG_SHIFT 0
+#define LOG_WARN_MASK   0x00f0
+#define LOG_WARN_SHIFT  4
+#define LOG_ERROR_MASK  0x0f00
+#define LOG_ERROR_SHIFT 8
+
+static unsigned log_options =
+    (LOG_DEST_FILE << LOG_DEBUG_SHIFT) |
+    ((LOG_DEST_FILE|LOG_DEST_STDERR) << LOG_WARN_SHIFT) |
+    ((LOG_DEST_FILE|LOG_DEST_MSGBOX) << LOG_ERROR_SHIFT);
+
+static const char log_fn[] = "b-emlog.txt";
+FILE *log_fp;
+
+static char   tmstr[20];
+static time_t last = 0;
+
+static void log_common(unsigned dest, const char *level, const char *msg, size_t len)
+{
+    time_t now;
+
+    while (msg[len-1] == '\n')
+	len--;
+    if ((dest & LOG_DEST_FILE) && log_fp) {
+	time(&now);
+	if (now != last)
+	{
+	    strftime(tmstr, sizeof(tmstr), "%d/%m/%Y %H:%M:%S", localtime(&now));
+	    last = now;
+	}
+	fprintf(log_fp, "%s %s ", tmstr, level); 
+	fwrite(msg, len, 1, log_fp);
+	putc('\n', log_fp);
+	fflush(log_fp);
+    }
+    if (dest & LOG_DEST_STDERR) {
+	fwrite(msg, len, 1, stderr);
+	putc('\n', stderr);
+    }
+    if (dest & LOG_DEST_MSGBOX) {
+#ifdef WIN32
+	win_log_msgbox(level, msg);
+#else
+	alert(level, msg, "", "&OK", NULL, 'a', 0);
+#endif
+    }
+}
+
+static void log_plain(unsigned mask, unsigned shift, const char *level, const char *msg)
+{
+    unsigned opt = log_options & mask;
+
+    if (opt)
+	log_common(opt >> shift, level, msg, strlen(msg));
+}
+
+static const char msg_malloc[] = "log_format: out of space - following message truncated";
+
+static void log_format(unsigned mask, unsigned shift, const char *level, const char *fmt, va_list ap)
+{
+    unsigned opt, dest;
+    char   abuf[200], *mbuf;
+    size_t len;
+
+    if ((opt = log_options & mask))
+    {
+	dest = opt >> shift;
+	len = vsnprintf(abuf, sizeof abuf, fmt, ap);
+	if (len <= sizeof abuf)
+	    log_common(dest, level, abuf, len);
+	else if ((mbuf = malloc(len + 1))) {
+	    vsnprintf(mbuf, len, fmt, ap);
+	    log_common(dest, level, mbuf, len);
+	    free(mbuf);
+	} else {
+	    log_common(dest, level, msg_malloc, sizeof msg_malloc);
+	    log_common(dest, level, abuf, len);
+	}
+    }
+}
 
 #ifdef _DEBUG
-static const char debug_fn[] = "b-emlog.txt";
-FILE *debug_fp;
 
 void bem_debug(const char *s)
 {
-        if (debug_fp)
-        {
-                fputs(s, debug_fp);
-                fflush(debug_fp);
-        }
+    log_plain(LOG_DEBUG_MASK, LOG_DEBUG_SHIFT, "DEBUG", s);
 }
 
 void bem_debugf(const char *fmt, ...)
 {
-        va_list ap;
+    va_list ap;
 
-        if (debug_fp)
-        {
-                va_start(ap, fmt);
-                vfprintf(debug_fp, fmt, ap);
-                va_end(ap);
-                fflush(debug_fp);
-        }
+    va_start(ap, fmt);
+    log_format(LOG_DEBUG_MASK, LOG_DEBUG_SHIFT, "DEBUG", fmt, ap);
+    va_end(ap);
 }
 
 #endif
 
-void bem_errorf(const char *fmt, ...)
-{
-        char buf[256];
-        va_list ap;
-
-        va_start(ap, fmt);
-        vsnprintf(buf, sizeof buf, fmt, ap);
-        va_end(ap);
-
-        bem_error(buf);
-        bem_debug(buf);
-}
-
 void bem_warn(const char *s)
 {
-        fputs(s, stderr);
-        fputc('\n', stderr);
+    log_plain(LOG_WARN_MASK, LOG_WARN_SHIFT, "WARNING", s);
 }
 
 void bem_warnf(const char *fmt, ...)
 {
-        char buf[256];
-        va_list ap;
+    va_list ap;
 
-        va_start(ap, fmt);
-        vsnprintf(buf, sizeof buf, fmt, ap);
-        va_end(ap);
-
-        bem_warn(buf);
-        bem_debug(buf);
+    va_start(ap, fmt);
+    log_format(LOG_WARN_MASK, LOG_WARN_SHIFT, "WARNING", fmt, ap);
+    va_end(ap);
 }
 
-#ifdef _DEBUG
-
-void debug_open()
+void bem_error(const char *s)
 {
-        if ((debug_fp = fopen(debug_fn, "wt")) == NULL)
-                bem_warnf("unable to open debug log %s: %s", debug_fn, strerror(errno));
+    log_plain(LOG_ERROR_MASK, LOG_ERROR_SHIFT, "ERROR", s);
 }
 
-void debug_close(void)
+void bem_errorf(const char *fmt, ...)
 {
-        if (debug_fp)
-                fclose(debug_fp);
+    va_list ap;
+
+    va_start(ap, fmt);
+    log_format(LOG_ERROR_MASK, LOG_ERROR_SHIFT, "ERROR", fmt, ap);
+    va_end(ap);
 }
 
-#endif
+void log_open(void)
+{
+    log_options = get_config_int(NULL, "logging", log_options);
+    if ((log_fp = fopen(log_fn, "at")) == NULL)
+	bem_warnf("log_open: unable to open log %s: %s", log_fn, strerror(errno));
+    bem_debugf("log_open: log options=%d", log_options);
+}
+
+void log_close(void)
+{
+    if (log_fp)
+	fclose(log_fp);
+}

--- a/src/logging.c
+++ b/src/logging.c
@@ -13,13 +13,16 @@
 
 #define LOG_DEBUG_MASK  0x000f
 #define LOG_DEBUG_SHIFT 0
-#define LOG_WARN_MASK   0x00f0
-#define LOG_WARN_SHIFT  4
-#define LOG_ERROR_MASK  0x0f00
-#define LOG_ERROR_SHIFT 8
+#define LOG_INFO_MASK   0x00f0
+#define LOG_INFO_SHIFT  4
+#define LOG_WARN_MASK   0x0f00
+#define LOG_WARN_SHIFT  8
+#define LOG_ERROR_MASK  0xf000
+#define LOG_ERROR_SHIFT 12
 
 static unsigned log_options =
     (LOG_DEST_FILE << LOG_DEBUG_SHIFT) |
+    (LOG_DEST_FILE << LOG_INFO_SHIFT)  |
     ((LOG_DEST_FILE|LOG_DEST_STDERR) << LOG_WARN_SHIFT) |
     ((LOG_DEST_FILE|LOG_DEST_MSGBOX) << LOG_ERROR_SHIFT);
 
@@ -110,6 +113,20 @@ void bem_debugf(const char *fmt, ...)
 }
 
 #endif
+
+void bem_info(const char *s)
+{
+    log_plain(LOG_INFO_MASK, LOG_INFO_SHIFT, "INFO", s);
+}
+
+void bem_infof(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    log_format(LOG_INFO_MASK, LOG_INFO_SHIFT, "INFO", fmt, ap);
+    va_end(ap);
+}
 
 void bem_warn(const char *s)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -111,7 +111,7 @@ void main_init(int argc, char *argv[])
         int c;
         int tapenext = 0, discnext = 0;
 
-        debug_open();
+        log_open();
 
         startblit();
         
@@ -120,7 +120,6 @@ void main_init(int argc, char *argv[])
 	vid_fskipmax = 1;
         
         al_init_main(argc, argv);
-        
         
         append_filename(t, exedir, "roms\\tube\\ReCo6502ROM_816", 511);
         if (!file_exists(t,FA_ALL,NULL) && selecttube == 4) selecttube = -1;
@@ -393,7 +392,7 @@ void main_close()
         
         al_close();
         video_close();
-        debug_close();
+        log_close();
 }
 
 void changetimerspeed(int i)

--- a/src/main.c
+++ b/src/main.c
@@ -112,6 +112,7 @@ void main_init(int argc, char *argv[])
         int tapenext = 0, discnext = 0;
 
         log_open();
+	bem_infof("main: starting %s", VERSION_STR);
 
         startblit();
         
@@ -267,9 +268,6 @@ void main_init(int argc, char *argv[])
         
         if (curtube == 3 || mouse_amx) install_mouse();
 
-//printf("Disc 0 : %s\n",discfns[0]);
-//printf("Disc 1 : %s\n",discfns[1]);
-//printf("Tape   : %s\n",tape_fn);
         disc_load(0, discfns[0]);
         disc_load(1, discfns[1]);
         tape_load(tape_fn);

--- a/src/tape.c
+++ b/src/tape.c
@@ -31,8 +31,8 @@ void tape_load(char *fn)
 
         if (!fn) return;
         p = get_extension(fn);
-        if (!p) return;
-        bem_debugf("Loading %s %s\n", fn, p);
+        if (!p || !*p) return;
+        bem_infof("tape: Loading %s %s", fn, p);
         while (loaders[c].ext)
         {
                 if (!strcasecmp(p, loaders[c].ext))

--- a/src/vdfs.c
+++ b/src/vdfs.c
@@ -282,11 +282,11 @@ static void scan_entry(vdfs_ent_t *ent) {
     // build name of .inf file
     host_dir_path = ent->parent->host_path;
     ptr = host_file_path = malloc(strlen(host_dir_path) + strlen(ent->host_fn) + 6);
-    if (host_dir_path[0] != '.' || host_dir_path[1] != '\0') {
-        ptr = stpcpy(ptr, host_dir_path);
-        *ptr++ = '/';
+    ptr = stpcpy(ptr, host_dir_path);
+    if (ent->host_fn[0] != '.' || ent->host_fn[1] != '\0') {
+	*ptr++ = '/';
+	ptr = stpcpy(ptr, ent->host_fn);
     }
-    ptr = stpcpy(ptr, ent->host_fn);
     strcpy(ptr, ".inf");
 
     // open and parse .inf file
@@ -611,17 +611,35 @@ void vdfs_close(void) {
 }
 
 void vdfs_new_root(const char *root) {
-    root_dir.host_fn = root_dir.host_path = strdup(root);
-    scan_entry(&root_dir);
-    cur_dir = lib_dir = prev_dir = &root_dir;
-    scan_seq++;
+    size_t len;
+    char   *path;
+    int    ch;
+
+    len = strlen(root);
+    while (len > 0 && ((ch = root[--len]) == '/' || ch == '\\'))
+	;
+    if (++len > 0) {
+	if ((path = malloc(len + 1))) {
+	    memcpy(path, root, len);
+	    path[len] = '\0';
+	    root_dir.host_path = path;
+	    root_dir.host_fn = ".";
+	    scan_entry(&root_dir);
+	    cur_dir = lib_dir = prev_dir = &root_dir;
+	    scan_seq++;
+	} else {
+	    bem_warn("vdfs: unable to set root as unable to allocate path.  VDFS disabled");
+	    vdfs_enabled = 0;
+	}
+    } else {
+	bem_warn("vdfs: unable to set root as path is empty.  VDFS disabled");
+	vdfs_enabled = 0;
+    }
 }
 
 void vdfs_set_root(const char *root) {
-    if (root_dir.host_path == NULL || strcmp(root_dir.host_path, root)) {
-        vdfs_close();
-        vdfs_new_root(root);
-    }
+    vdfs_close();
+    vdfs_new_root(root);
 }
 
 const char *vdfs_get_root() {
@@ -1201,6 +1219,7 @@ static uint16_t srp_hex(int ch, uint16_t addr, uint16_t *vptr) {
         *vptr = value;
         return --addr;
     }
+    *vptr = 0;
     return 0;
 }
 

--- a/src/win.c
+++ b/src/win.c
@@ -283,9 +283,12 @@ void updatewindowtitle()
            set_window_title(VERSION_STR);
 }
 
-void bem_error(char *s)
+void win_log_msgbox(const char *level, const char *s)
 {
-        MessageBox(ghwnd, s, "B-em error", MB_OK | MB_ICONEXCLAMATION);
+    char title[14];
+
+    snprintf(title, sizeof title, "B-Em: %s", level);
+    MessageBox(ghwnd, s, title, MB_OK | MB_ICONEXCLAMATION);
 }
 
 int WINAPI WinMain (HINSTANCE hThisInstance,


### PR DESCRIPTION
The mejor piece of this is a re-write of the logging.c module so it can send message of each class (DEBUG, WARNING, ERROR) to each of three destinations (log file, stderr, message box) according to a config variable.  In the process it fixes Issue '17 by enabling warnings to go to the log file as default behaviour.