### PR TITLE
Allow normal typing in free run mode

### DIFF
--- a/src/b-em.h
+++ b/src/b-em.h
@@ -33,6 +33,7 @@ extern char exedir[512];
 extern int joybutton[2];
 
 extern int bempause;
+extern int bemfreerun;
 
 void setquit();
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -37,7 +37,8 @@ static uint8_t codeconvert[128]=
 static inline void key_press(int row, int col)
 {
         bbckey[col][row] = 1;
-        bemfreerun = 2;
+        if (bemfreerun)
+            bemfreerun = 2;
 }
 
 static inline void key_release(int row, int col)

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -37,6 +37,7 @@ static uint8_t codeconvert[128]=
 static inline void key_press(int row, int col)
 {
         bbckey[col][row] = 1;
+        bemfreerun = 2;
 }
 
 static inline void key_release(int row, int col)
@@ -59,6 +60,17 @@ void key_clear()
         int row, col;
         for (c = 0; c < 128; c++)
                 if (TranslateKey(codeconvert[keylookup[c]], &row, &col) > 0) key_release(row,col);
+}
+
+int key_any_down()
+{
+    for (int i = 0; i < 16; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            if (bbckey[i][j])
+                return 1;
+        }
+    }
+    return 0;
 }
 
 static void key_update()

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -7,6 +7,7 @@ extern int keylookup[128];
 extern int keyas;
 
 extern void key_clear();
+extern int key_any_down();
 extern void key_check();
 extern void key_scan(int row, int col);
 extern int key_is_down(void);

--- a/src/main.c
+++ b/src/main.c
@@ -341,7 +341,14 @@ void main_run()
             bemfreerun = 0;
     }
 
-        if ((fcount > 0 || bemfreerun || (motor && fasttape)))
+    if (bemfreerun == 2) {
+        // A key was pressed while freerunning; disable freerun temporarily
+        // until no key is pressed any more.
+        if (!key_any_down())
+            bemfreerun = 1;
+    }
+
+        if ((fcount > 0 || (bemfreerun == 1) || (motor && fasttape)))
         {
                 if (autoboot) autoboot--;
                 fcount--;


### PR DESCRIPTION
This is more of an RFC that a straight pull request but I thought this would be a convenient way for people to see the code.

This is a small change which temporarily disables free run mode while an emulated key is pressed down. The upshot of this is that you can toggle free run mode on by pressing SHIFT-PAGE UP, giving you a fast emulated machine, but you can still type normally without the emulated machine's OS seeing that each key is held down for a long time and triggering auto-repeat.

Without this patch, if I do SHIFT-PAGE UP and type "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG" I get something like "THEEE QUICCK BROOWN FOX  JUMPPS OVER THE LAZY DOOGG"; with this patch, I can type normally even after SHIFT-PAGE UP.

I think this is useful for running non-game applications (compilers, text editors, etc), particularly when using the emulator to do development of new application on.

It might be worth supporting this when using speeds other than 100%, but I haven't looked into that yet  - currently it only affects free run mode.