### PR TITLE
Minor changes to get b-em/sf/allegro5 to build on latest macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_ARG_ENABLE(debug,
 	      AC_HELP_STRING([--enable-debug], [build debug executable]))
 
 CF_WARNINGS="-Wall -Wno-format-security"
-CFLAGS="$CFLAGS $CF_WARNINGS -std=gnu99 -D_GNU_SOURCE"
+CFLAGS="$CFLAGS $CF_WARNINGS -std=gnu11 -D_GNU_SOURCE"
 if test "$enable_debug" = "yes"; then
    CFLAGS="$CFLAGS -O3 -ggdb -D_DEBUG"
    LDFLAGS="$LDFLAGS -L/usr/local/lib"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,7 @@ b_em_CFLAGS = $(allegro_CFLAGS) -DBEM -DINCLUDE_DEBUGGER -DUSE_MEMORY_POINTER
 if OS_WIN
 b_em_LDADD = -lallegro_audio -lallegro_acodec -lallegro_primitives -lallegro_dialog -lallegro_image -lallegro_font -lallegro -lz -lm
 else
-b_em_LDADD = -lallegro_audio -lallegro_acodec -lallegro_primitives -lallegro_dialog -lallegro_image -lallegro_font -lallegro -lz -lm -lpthread
+b_em_LDADD = -lallegro_audio -lallegro_acodec -lallegro_primitives -lallegro_dialog -lallegro_image -lallegro_font -lallegro_main -lallegro -lz -lm -lpthread
 endif
 
 b_em_SOURCES = \
@@ -122,4 +122,4 @@ endif
 
 jstest_SOURCES = jstest.c
 
-jstest_LDADD = -lallegro
+jstest_LDADD = -lallegro -lallegro_main


### PR DESCRIPTION
- Switch to gnu11 from gnu99 to make static_assert work, and get rid of a _static_assert symbol not found error when linking.
- Add -lallegro_main when linking, to get rid of a _main symbol not found error.