### PR TITLE
Fix a compiler warning by including <pthread.h>.

### DIFF
--- a/src/midi-linux.c
+++ b/src/midi-linux.c
@@ -4,8 +4,13 @@
 #include "music4000.h"
 #include "midi-linux.h"
 #include "sound.h"
-//#include <pthread.h>
-//#include <unistd.h>
+
+#if HAVE_ALSA_ASOUNDLIB_H
+// We only include these header files for ALSA since
+// they may not exist on non-POSIX platforms.
+# include <pthread.h>
+# include <unistd.h>
+#endif
 
 midi_dev_t midi_music4000;
 midi_dev_t midi_music2000_out1;


### PR DESCRIPTION
When HAVE_ALSA_ASOUNDLIB_H is #defined, we're going to use functions
from pthread.h, so #include it.  Do not include it otherwise, so we
don't break compilation on platforms that don't have it (since
configure will have ensured that HAVE_ALSA_ASOUNDLIB_H is not defined
on those).