### PR TITLE
Coeus symbols

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -919,7 +919,10 @@ void debugger_do(cpu_debug_t *cpu, uint32_t addr)
             case 't':
             case 'T':
                 if (trace_fp)
+                {
                     fclose(trace_fp);
+                    trace_fp = NULL;
+                }
                 if (*iptr) {
                     if ((eptr = strchr(iptr, '\n')))
                         *eptr = '\0';

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -679,6 +679,10 @@ void debugger_do(cpu_debug_t *cpu, uint32_t addr)
 
     main_pause();
     indebug = 1;
+    const char *sym;
+    if (symbol_find_by_addr(cpu->symbols, addr, &sym)) {
+        debug_outf("%s:\n", sym);
+    }
     log_debug("debugger: about to call disassembler, addr=%04X", addr);
     next_addr = cpu->disassemble(cpu, addr, ins, sizeof ins);
     debug_out(ins, strlen(ins));


### PR DESCRIPTION
Two tweaks:
 - null the trace_fp pointer when a trace is closed - was causing fatal crashes
 - show symbol when entering debugger - not sure if this should show a "near" symbol, at present shows closest