### PR TITLE
Allow command line specification of emulation speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Command Line Options
 ====================
 
 ```
-b-em [discimage|tapeimage|snapshot] [-u name.uef] [-mx] [-tx] [-i] [-c] [-fx]
+b-em [discimage|tapeimage|snapshot] [-u name.uef] [-mx] [-tx] [-i] [-c] [-fx] [-spx]
 ```
 
 `discimage` name.ssd/dsd/adf/adl/img etc.
@@ -421,6 +421,8 @@ b-em [discimage|tapeimage|snapshot] [-u name.uef] [-mx] [-tx] [-i] [-c] [-fx]
 `-fx` - set frameskip to x (1-9, 1=no skip)
 
 `-fasttape` - speeds up tape access
+
+`-spx` - emlation speed where x is 0 to 9 (default = 4)
 
 
 IDE Hard Discs

--- a/src/main.c
+++ b/src/main.c
@@ -140,6 +140,7 @@ static const char helptext[] =
     "-Fx             - set maximum video frames skipped\n"
     "-s              - scanlines display mode\n"
     "-i              - interlace display mode\n"
+    "-spx             - Emulation speed x from 0 to 9 (default 4)\n"
     "-debug          - start debugger\n"
     "-debugtube      - start debugging tube processor\n\n";
 
@@ -167,9 +168,14 @@ void main_init(int argc, char *argv[])
     model_loadcfg();
 
     for (c = 1; c < argc; c++) {
-        if (!strcasecmp(argv[c], "--help")) {
+        if (!strcasecmp(argv[c], "--help") || !strcasecmp(argv[c], "-?") || !strcasecmp(argv[c], "-h")) {
             fwrite(helptext, sizeof helptext-1, 1, stdout);
             exit(1);
+        }
+        else if (!strncasecmp(argv[c], "-sp", 3)) {
+            sscanf(&argv[c][3], "%i", &emuspeed);
+            if(!(emuspeed < NUM_EMU_SPEEDS))
+                emuspeed = 4;
         }
         else if (!strcasecmp(argv[c], "-tape"))
             tapenext = 2;
@@ -317,6 +323,7 @@ void main_init(int argc, char *argv[])
         gui_set_disc_wprot(0, writeprot[0]);
     if (discfns[1])
         gui_set_disc_wprot(1, writeprot[1]);
+    main_setspeed(emuspeed);        
     debug_start();
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -1,7 +1,7 @@
 #ifndef __INC_MAIN_H
 #define __INC_MAIN_H
 
-#define NUM_EMU_SPEEDS   12
+#define NUM_EMU_SPEEDS   10
 #define EMU_SPEED_FULL   255
 #define EMU_SPEED_PAUSED 254
 


### PR DESCRIPTION
1. Added command line switch for emulation speed (-spx)
2. Extended help switches to included (-?) and (-h)
3. Changed the #define for maximum speeds to 10 (was set to 12 even though 10 specified)
4. (3) allows checking of the range of the -spx x parameter correctly without causing allegro to fall over