### PR TITLE
Typo corrected in --help and in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ b-em [discimage|tapeimage|snapshot] [-u name.uef] [-mx] [-tx] [-i] [-c] [-fx] [-
 
 `-fasttape` - speeds up tape access
 
-`-spx` - emlation speed where x is 0 to 9 (default = 4)
+`-spx` - emulation speed where x is 0 to 9 (default = 4)
 
 
 IDE Hard Discs

--- a/src/main.c
+++ b/src/main.c
@@ -140,7 +140,7 @@ static const char helptext[] =
     "-Fx             - set maximum video frames skipped\n"
     "-s              - scanlines display mode\n"
     "-i              - interlace display mode\n"
-    "-spx             - Emulation speed x from 0 to 9 (default 4)\n"
+    "-spx            - Emulation speed x from 0 to 9 (default 4)\n"
     "-debug          - start debugger\n"
     "-debugtube      - start debugging tube processor\n\n";
 


### PR DESCRIPTION
Two minor typos fixed:

1. --help text had an errant space in for -spx
2. README.md had a missing u in emulation