### PR TITLE
Set Allegro VSYNC to off

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -759,6 +759,8 @@ ALLEGRO_DISPLAY *video_init(void)
     al_set_new_display_flags(ALLEGRO_WINDOWED | ALLEGRO_RESIZABLE);
 #endif
     video_set_window_size(true);
+
+    al_set_new_display_option(ALLEGRO_VSYNC, 2, ALLEGRO_SUGGEST);
     if ((display = al_create_display(winsizex, winsizey)) == NULL) {
         log_fatal("video: unable to create display");
         exit(1);


### PR DESCRIPTION
Call al_set_new_display_option to suppress vsync to improve performance

Without this on an i7 3GHz machine on Ubuntu 20.04 with an NVidia card I only get 60% / 1.2 MHz at 100%
With this display option set this increases to 100% / 2 Mhz

Tested with White Light and no screen tearing apparent at all on Linux or RPi.

Note that this can be overriden by the graphics driver or sometimes not supported - for the latter case ALLEGRO_SUGGEST will still allow the display to be created.