### PR TITLE
Compiling version of B-em on Visual Studio 2019

### DIFF
--- a/src/b-em.vcxproj
+++ b/src/b-em.vcxproj
@@ -14,21 +14,21 @@
     <ProjectGuid>{28E2DE55-0A88-47FA-92DC-3F96D72608F9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>bem</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -70,6 +70,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>VERSION="vsX";USE_MEMORY_POINTER;BEM;WIN32;INCLUDE_DEBUGGER;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UndefinePreprocessorDefinitions>UNICODE;_UNICODE;%(UndefinePreprocessorDefinitions)</UndefinePreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\packages\Allegro.5.2.6\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -89,6 +90,7 @@
       <PreprocessorDefinitions>VERSION="vsX";USE_MEMORY_POINTER;BEM;WIN32;INCLUDE_DEBUGGER;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UndefinePreprocessorDefinitions>UNICODE;_UNICODE;%(UndefinePreprocessorDefinitions)</UndefinePreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\packages\Allegro.5.2.6\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -117,6 +119,7 @@
     <ClInclude Include="compact_joystick.h" />
     <ClInclude Include="compat_wrappers.h" />
     <ClInclude Include="config.h" />
+    <ClInclude Include="copro-pdp11.h" />
     <ClInclude Include="cpu_debug.h" />
     <ClInclude Include="csw.h" />
     <ClInclude Include="daa.h" />
@@ -134,12 +137,14 @@
     <ClInclude Include="fdi.h" />
     <ClInclude Include="fdi2raw.h" />
     <ClInclude Include="gui-allegro.h" />
+    <ClInclude Include="hfe.h" />
     <ClInclude Include="i8271.h" />
     <ClInclude Include="ide.h" />
+    <ClInclude Include="imd.h" />
     <ClInclude Include="joystick.h" />
     <ClInclude Include="keyboard.h" />
     <ClInclude Include="keydef-allegro.h" />
-    <ClInclude Include="linux-gui.h" />
+    <ClInclude Include="led.h" />
     <ClInclude Include="logging.h" />
     <ClInclude Include="main.h" />
     <ClInclude Include="mc6809nc\mc6809.h" />
@@ -162,6 +167,8 @@
     <ClInclude Include="NS32016\Trap.h" />
     <ClInclude Include="pal.h" />
     <ClInclude Include="paula.h" />
+    <ClInclude Include="pdp11\pdp11.h" />
+    <ClInclude Include="pdp11\pdp11_debug.h" />
     <ClInclude Include="resid-fp\envelope.h" />
     <ClInclude Include="resid-fp\extfilt.h" />
     <ClInclude Include="resid-fp\filter.h" />
@@ -214,6 +221,7 @@
     <ClCompile Include="compact_joystick.c" />
     <ClCompile Include="compat_wrappers.c" />
     <ClCompile Include="config.c" />
+    <ClCompile Include="copro-pdp11.c" />
     <ClCompile Include="csw.c" />
     <ClCompile Include="darm\armv7-tbl.c" />
     <ClCompile Include="darm\armv7.c" />
@@ -231,14 +239,14 @@
     <ClCompile Include="fdi.c" />
     <ClCompile Include="fdi2raw.c" />
     <ClCompile Include="gui-allegro.c" />
+    <ClCompile Include="hfe.c" />
     <ClCompile Include="i8271.c" />
     <ClCompile Include="ide.c" />
+    <ClCompile Include="imd.c" />
     <ClCompile Include="joystick.c" />
     <ClCompile Include="keyboard.c" />
     <ClCompile Include="keydef-allegro.c" />
-    <ClCompile Include="linux-gui.c" />
-    <ClCompile Include="linux-keydefine.c" />
-    <ClCompile Include="linux.c" />
+    <ClCompile Include="led.c" />
     <ClCompile Include="logging.c" />
     <ClCompile Include="main.c" />
     <ClCompile Include="mc6809nc\mc6809nc.c" />
@@ -260,6 +268,8 @@
     <ClCompile Include="NS32016\Trap.c" />
     <ClCompile Include="pal.c" />
     <ClCompile Include="paula.c" />
+    <ClCompile Include="pdp11\pdp11.c" />
+    <ClCompile Include="pdp11\pdp11_debug.c" />
     <ClCompile Include="resid-fp\convolve-sse.cc" />
     <ClCompile Include="resid-fp\convolve.cc" />
     <ClCompile Include="resid-fp\envelope.cc" />

--- a/src/b-em.vcxproj.filters
+++ b/src/b-em.vcxproj.filters
@@ -249,9 +249,6 @@
     <ClInclude Include="keydef-allegro.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="linux-gui.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="logging.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -295,6 +292,24 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="debugger_symbols.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="led.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="hfe.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="imd.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="copro-pdp11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="pdp11\pdp11.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="pdp11\pdp11_debug.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -359,15 +374,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="keyboard.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="linux.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="linux-gui.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="linux-keydefine.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="main.c">
@@ -608,6 +614,24 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="debugger_symbols.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="led.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="hfe.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="imd.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="copro-pdp11.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pdp11\pdp11.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pdp11\pdp11_debug.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/imd.c
+++ b/src/imd.c
@@ -129,6 +129,15 @@ static uint8_t wt_headid;
 static uint8_t wt_sectid;
 static uint8_t wt_sectsz;
 
+#ifdef WIN32
+// https://stackoverflow.com/a/19932364/433626
+int ftruncate(int fd, off_t length) {
+    HANDLE handle = (HANDLE) _get_osfhandle(_fileno(fd));
+    SetFilePointer(handle, length, 0, FILE_BEGIN);
+    SetEndOfFile(handle);
+}
+#endif
+
 /*
  * This function writes the IMD file in memory back to the disc file.
  * it does not re-write the comment at the start of the file but

--- a/src/model.c
+++ b/src/model.c
@@ -70,7 +70,9 @@ TUBE tubes[NUM_TUBES]=
     {"Z80 ROM 2.00",   z80_init,        z80_reset,       &tubez80_cpu_debug,   0x1000, "Z80_200",          6 },
     {"PDP11",          tube_pdp11_init, copro_pdp11_rst, &pdp11_cpu_debug,     0x0800, "PDP11Tube",        2 },
     {"6502 Turbo",     tube_6502_iturb, tube_6502_reset, &tube6502_cpu_debug,  0x0800, "6502Turbo",        4 },
+#ifdef M68K
     {"68000",          tube_68000_init, tube_68000_rst,  &mc68000_cpu_debug,   0x8000, "CiscOS",           4 }
+#endif
 };
 
 static fdc_type_t model_find_fdc(const char *name, const char *model)

--- a/src/sdf-acc.c
+++ b/src/sdf-acc.c
@@ -406,18 +406,22 @@ static void sdf_spinup(int drive)
 {
     FILE *fp = sdf_fp[drive];
     log_debug("sdf: spinup drive %d", drive);
+#ifndef WIN32
     if (fp)
         sdf_lock(drive, fp, F_WRLCK);
+#endif
 }
 
 static void sdf_spindown(int drive)
 {
     FILE *fp = sdf_fp[drive];
     log_debug("sdf: spindown drive %d", drive);
+#ifndef WIN32
     if (fp) {
         fflush(fp);
         sdf_lock(drive, fp, F_UNLCK);
     }
+#endif
 }
 
 static void sdf_mount(int drive, const char *fn, FILE *fp, const struct sdf_geometry *geo)

--- a/src/tube.c
+++ b/src/tube.c
@@ -75,14 +75,18 @@ void tube_updateints()
                 if (((m_pdp11->PS >> 5) & 7) < 6)
                     pdp11_interrupt(0x84, 6);
             }
+#ifdef M68K
             else if (tube_type == TUBE68000)
                 m68k_set_virq(2, 1);
+#endif
         }
     }
     else if (tube_irq & 1) {
+#ifdef M68K
         log_debug("tube: parasite IRQ de-asserted");
         if (tube_type == TUBE68000)
             m68k_set_virq(2, 0);
+#endif
     }
 
     if (tubeula.r1stat & 8 && (tubeula.ph3pos == 0 || tubeula.hp3pos > (tubeula.r1stat & 16) ? 1 : 0)) {


### PR DESCRIPTION
- exclude linux source files from VS project
- v141 -> v142
- re-include pdp11 tube files
- re-include led.*, hfe.*, and imd.* files
- Win32 implementation of ftruncate
- Excluding 68000 tube which can be turned on by #define M68K
- Not using sdf_lock functions on Win32