### PR TITLE
Another Partial fix for Issue #140

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ AC_CANONICAL_HOST
 # Set up the compiler in two different ways and say yes we may want to install.
 AC_PROG_CC
 AC_PROG_CXX
+CXXFLAGS="$CXXFLAGS -std=gnu++11"
 AM_PROG_CC_C_O
 
 # Whether this is a released build or not.


### PR DESCRIPTION
Partial fix for Issue #140.  This removes the error: expression expected in debugger_symbols.cpp

debugger_symbols.cpp:32:16: error: expected expression
    map.insert({ e->getSymbol(), e });
               ^

The remaining issue with gtest and sdf2imd I am still looking into to see if I can find a proper fix.