### PR TITLE
Fix for last outstanding problem for issue #140. The library allegro_…

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,4 +147,8 @@ jstest_LDADD = -lallegro -lallegro_main
 
 gtest_SOURCES = sdf-gtest.c sdf-geo.c
 
+gtest_LDADD = -lallegro_main
+
 sdf2imd_SOURCES = sdf2imd.c sdf-geo.c
+
+sdf2imd_LDADD = -lallegro_main


### PR DESCRIPTION
Fix for last outstanding problem for issue #140. The library allegro_main is still required for Mac OS X, but not for windows or linux which are both empty libraries.

This library is only required for gtest and sdf2imd, and causes the build to fail if added to all the other programs.