### PR TITLE
Set install permissions for data files to 644 and 755

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,5 +5,5 @@ dist_pkgdata_DATA = b-em.cfg
 install-data-hook:
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	cp -r ddnoise discs fonts roms tapes $(DESTDIR)$(pkgdatadir)
-	find $(DESTDIR)$(pkgdatadir) -type f -print0 | xargs -0 chmod 444
-	find $(DESTDIR)$(pkgdatadir) -type d -print0 | xargs -0 chmod 555
+	find $(DESTDIR)$(pkgdatadir) -type f -print0 | xargs -0 chmod 644
+	find $(DESTDIR)$(pkgdatadir) -type d -print0 | xargs -0 chmod 755


### PR DESCRIPTION
This prevents issues with the flatpak building tools that expect root to
have write access to installed files.

Fixes #151 