### PR TITLE
Add desktop and metadata files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,9 @@ SUBDIRS = src
 dist_doc_DATA = README.md
 dist_pkgdata_DATA = b-em.cfg
 
+desktopdir = $(datadir)/applications
+desktop_DATA = uk.org.stardot.b-em.desktop
+
 install-data-hook:
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	cp -r ddnoise discs fonts roms tapes $(DESTDIR)$(pkgdatadir)

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,9 @@ dist_pkgdata_DATA = b-em.cfg
 desktopdir = $(datadir)/applications
 desktop_DATA = uk.org.stardot.b-em.desktop
 
+appicondir=$(datadir)/icons/hicolor/scalable/apps
+appicon_DATA=icon/b-em.svg
+
 install-data-hook:
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	cp -r ddnoise discs fonts roms tapes $(DESTDIR)$(pkgdatadir)

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,9 @@ desktop_DATA = uk.org.stardot.b-em.desktop
 appicondir=$(datadir)/icons/hicolor/scalable/apps
 appicon_DATA=icon/b-em.svg
 
+appdatadir = $(datadir)/metainfo
+appdata_DATA = uk.org.stardot.b-em.metainfo.xml
+
 install-data-hook:
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	cp -r ddnoise discs fonts roms tapes $(DESTDIR)$(pkgdatadir)

--- a/uk.org.stardot.b-em.desktop
+++ b/uk.org.stardot.b-em.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Version=1.4
+Name=B-Em
+Comment=An opensource BBC Micro emulator
+Exec=b-em
+Icon=b-em
+Terminal=false
+Categories=System;Emulator;
+Keywords=BBC Micro;Emulation;

--- a/uk.org.stardot.b-em.metainfo.xml
+++ b/uk.org.stardot.b-em.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2020 B-Em developers -->
+<component type="desktop-application">
+  <id>uk.org.stardot.b-em</id>
+  <name>B-Em</name>
+  <summary>An opensource BBC Micro emulator</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <launchable type="desktop-id">uk.org.stardot.b-em.desktop</launchable>
+  <content_rating type="oars-1.1"/>
+
+  <description>
+    <p>
+      An opensource BBC Micro emulator for Win32 and Linux
+    </p>
+    <p>
+      B-em is an emulator for various models of BBC Microcomputer as made by Acorn Computers in the 1980s along with a selection of 2nd processors. It is supported for Win32 and Linux/UNIX but may also work on other systems supported by the Allegro library.
+    </p>
+  </description>
+
+  <url type="homepage">https://github.com/stardot/b-em</url>
+  <url type="bugtracker">https://github.com/stardot/b-em/issues</url>
+
+  <releases>
+    <release version="2.2" date="2012-06-03">
+      <description>
+        <p>
+          Improvements and bug fixes.
+        </p>
+        <ul>
+          <li>MOS 3.50 emulation</li>
+          <li>Fixed CRTC bug when programmed with stupid values (MOS 3.50 startup)</li>
+          <li>ADFS disc corruption bug fixed (Carlo Concari)</li>
+          <li>Fixed ACIA bug - Pro Boxing Simulator tape version now works</li>
+          <li>Fixed bug which created endless blank hard disc images</li>
+          <li>Printer port DAC emulation</li>
+          <li>AMX mouse emulation</li>
+          <li>Master 512 mouse now works properly</li>
+          <li>Master Compact joystick emulation</li>
+          <li>IDE emulation available in non-Master models</li>
+          <li>UI fixes (some from Carlo Concari)</li>
+          <li>Improvements to VIA emulation</li>
+          <li>PAL video filter</li>
+          <li>Bugfixes in ARM and 65816 coprocessors</li>
+          <li>Debugger fixes</li>
+          <li>Tidying up of code</li>
+          <li>Windows version can now build on MSVC as well as GCC</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
To submit to Flathub there are a few requirements https://github.com/flathub/flathub/wiki/App-Requirements

This adds a .desktop and appstream .metadata files. It also installs these to the expected locations. This will also cause b-em to be added to the linux application menus when installed normally.

There are a few choice that might need reviewing.

1. The ID, I used uk.org.stardot.b-em , the b-em website in reverse DNS notation. an alternative would be  io.github.stardot.b-em . See https://docs.flatpak.org/en/latest/conventions.html#application-ids
2. File location. I just put these in the top directory, they could also go in a /data directory
3. All the descriptions
4. Categories, There are few possible options, see https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry

There are few other things needed to be included on flathub:

A tagged release. Flathub needs to build from a release tag https://github.com/flathub/flathub/wiki/App-Requirements#stable-releases-reproducible-builds

Sandbox permissions. Ideally flatpak packages are sandboxed with limited access to the filesystem. I think most users would want read and write access to disks stored in their home folder. But this could be restricted to only the document folder. This would be specified in the flatpak yaml file that gets put in the flatpak repository.