### PR TITLE
Only hide menu when going fullscreen from keyboard

### DIFF
--- a/src/fullscreen.c
+++ b/src/fullscreen.c
@@ -6,8 +6,6 @@ extern ALLEGRO_EVENT_QUEUE *queue;
 extern ALLEGRO_DISPLAY *tmp_display;
 void enter_fullscreen()
 {
-    video_enterfullscreen();
-    gui_allegro_destroy(queue, tmp_display);
 }
 
 void leave_fullscreen()
@@ -15,13 +13,26 @@ void leave_fullscreen()
     gui_allegro_init(queue, tmp_display);
     video_leavefullscreen();
 }
+void toggle_fullscreen_menu()
+{
+    if (fullscreen) {
+        fullscreen = 0;
+        gui_allegro_init(queue, tmp_display);
+        video_leavefullscreen();
+    } else {
+        fullscreen = 1;
+        video_enterfullscreen();
+        gui_allegro_destroy(queue, tmp_display);
+    }
+}
+
 void toggle_fullscreen()
 {
     if (fullscreen) {
         fullscreen = 0;
-        leave_fullscreen();
+        video_leavefullscreen();
     } else {
         fullscreen = 1;
-        enter_fullscreen();
+        video_enterfullscreen();
     }
 }

--- a/src/fullscreen.h
+++ b/src/fullscreen.h
@@ -1,3 +1,4 @@
 void enter_fullscreen();
 void leave_fullscreen();
 void toggle_fullscreen();
+void toggle_fullscreen_menu();

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -674,9 +674,9 @@ const struct key_act_const keyact_const[KEY_ACTION_MAX] = {
     { "break",        ALLEGRO_KEY_F12,   false, main_key_break,          do_nothing      },
     { "full-Speed",   ALLEGRO_KEY_PGUP,  false, main_start_fullspeed,    stop_full_speed },
     { "pause",        ALLEGRO_KEY_PGDN,  false, main_key_pause,          do_nothing      },
-    { "full-screen1", ALLEGRO_KEY_F11,   false, toggle_fullscreen, do_nothing      },
+    { "full-screen1", ALLEGRO_KEY_F11,   false, toggle_fullscreen_menu, do_nothing      },
     { "debug-break",  ALLEGRO_KEY_F10,   false, debug_break,             do_nothing      },
-    { "full-screen2", ALLEGRO_KEY_ENTER, true,  toggle_fullscreen, do_nothing      }
+    { "full-screen2", ALLEGRO_KEY_ENTER, true,  toggle_fullscreen_menu, do_nothing      }
 };
 
 uint8_t keylookup[ALLEGRO_KEY_MAX];


### PR DESCRIPTION
I've added a different function to keep the menu bar when you select fullscreen from the video menu.