### PR TITLE
Rp/clang warnings

### DIFF
--- a/src/ARMulator/armemu.c
+++ b/src/ARMulator/armemu.c
@@ -783,6 +783,7 @@ ARMul_Emulate26 (ARMul_State * state)
         {
             ARMword cp14r0;
             int ok;
+            int do_int = 0;
 
             ok = state->CPRead[14] (state, 0, & cp14r0);
 
@@ -816,7 +817,6 @@ ARMul_Emulate26 (ARMul_State * state)
 
                     state->CP14R0_CCD = (ARMword)-1;
 check_PMUintr:
-                    int do_int = 0;
                     cp14r0 |= ARMul_CP14_R0_FLAG2;
                     (void) state->CPWrite[14] (state, 0, cp14r0);
 

--- a/src/hdfmt.c
+++ b/src/hdfmt.c
@@ -101,7 +101,8 @@ int main(int argc, char **argv)
 {
         const char *fn;
         int status, len, size, sectors, cyl;
-        char *dat_fn, *dsc_fn, geom[22];
+        char *dat_fn, *dsc_fn;
+        unsigned char geom[22];
         FILE *dat_fp, *dsc_fp;
 
         if (argc == 3)

--- a/src/mmccard.c
+++ b/src/mmccard.c
@@ -84,7 +84,7 @@ void mmccard_write(uint8_t byte)
                             break;
                         case 0x50: // Set block length.
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
-                            log_debug("mmccard: set block length to %lx", address);
+                            log_debug("mmccard: set block length to %llx", address);
                             if (address > 0 && address <= sizeof(mmc_buffer)) {
                                 mmc_shiftreg = 0x00;
                                 mmc_block_len = address;
@@ -96,7 +96,7 @@ void mmccard_write(uint8_t byte)
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
                             if (mmc_sdhc_mode)
                                 address *= 0x200;
-                            log_debug("mmccard: read from %lx", address);
+                            log_debug("mmccard: read from %llx", address);
                             if (address < mmc_size) {
                                 if (!fseek(mmc_fp, address, SEEK_SET) && fread(mmc_buffer, mmc_block_len, 1, mmc_fp) == 1) {
                                     mmc_shiftreg = 0x00;
@@ -116,7 +116,7 @@ void mmccard_write(uint8_t byte)
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
                             if (mmc_sdhc_mode)
                                 address *= 0x200;
-                            log_debug("mmccard: write to %lx", address);
+                            log_debug("mmccard: write to %llx", address);
                             if (mmc_wprot) {
                                 mmc_shiftreg = 0xff;
                                 mmc_state = MMC_IDLE;
@@ -215,7 +215,7 @@ void mmccard_load(char *fn)
     fseek(fp, 0, SEEK_END);
     mmc_size = ftell(fp);
     mmc_fp = fp;
-    log_debug("mmcard: %s loaded, size=%ld", fn, mmc_size);
+    log_debug("mmcard: %s loaded, size=%lld", fn, mmc_size);
 }
 
 void mmccard_eject(void)

--- a/src/mmccard.c
+++ b/src/mmccard.c
@@ -84,7 +84,7 @@ void mmccard_write(uint8_t byte)
                             break;
                         case 0x50: // Set block length.
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
-                            log_debug("mmccard: set block length to %llx", (int64_t)address);
+                            log_debug("mmccard: set block length to %jx", (intmax_t)address);
                             if (address > 0 && address <= sizeof(mmc_buffer)) {
                                 mmc_shiftreg = 0x00;
                                 mmc_block_len = address;
@@ -96,7 +96,7 @@ void mmccard_write(uint8_t byte)
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
                             if (mmc_sdhc_mode)
                                 address *= 0x200;
-                            log_debug("mmccard: read from %llx", (int64_t)address);
+                            log_debug("mmccard: read from %jx", (intmax_t)address);
                             if (address < mmc_size) {
                                 if (!fseek(mmc_fp, address, SEEK_SET) && fread(mmc_buffer, mmc_block_len, 1, mmc_fp) == 1) {
                                     mmc_shiftreg = 0x00;
@@ -116,7 +116,7 @@ void mmccard_write(uint8_t byte)
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
                             if (mmc_sdhc_mode)
                                 address *= 0x200;
-                            log_debug("mmccard: write to %llx", (int64_t)address);
+                            log_debug("mmccard: write to %jx", (intmax_t)address);
                             if (mmc_wprot) {
                                 mmc_shiftreg = 0xff;
                                 mmc_state = MMC_IDLE;
@@ -215,7 +215,7 @@ void mmccard_load(char *fn)
     fseek(fp, 0, SEEK_END);
     mmc_size = ftell(fp);
     mmc_fp = fp;
-    log_debug("mmcard: %s loaded, size=%lld", fn, (int64_t)mmc_size);
+    log_debug("mmcard: %s loaded, size=%jd", fn, (intmax_t)mmc_size);
 }
 
 void mmccard_eject(void)

--- a/src/mmccard.c
+++ b/src/mmccard.c
@@ -84,7 +84,7 @@ void mmccard_write(uint8_t byte)
                             break;
                         case 0x50: // Set block length.
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
-                            log_debug("mmccard: set block length to %llx", address);
+                            log_debug("mmccard: set block length to %llx", (int64_t)address);
                             if (address > 0 && address <= sizeof(mmc_buffer)) {
                                 mmc_shiftreg = 0x00;
                                 mmc_block_len = address;
@@ -96,7 +96,7 @@ void mmccard_write(uint8_t byte)
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
                             if (mmc_sdhc_mode)
                                 address *= 0x200;
-                            log_debug("mmccard: read from %llx", address);
+                            log_debug("mmccard: read from %llx", (int64_t)address);
                             if (address < mmc_size) {
                                 if (!fseek(mmc_fp, address, SEEK_SET) && fread(mmc_buffer, mmc_block_len, 1, mmc_fp) == 1) {
                                     mmc_shiftreg = 0x00;
@@ -116,7 +116,7 @@ void mmccard_write(uint8_t byte)
                             address = (mmc_args[0] << 24) | (mmc_args[1] << 16) | (mmc_args[2] << 8) | mmc_args[3];
                             if (mmc_sdhc_mode)
                                 address *= 0x200;
-                            log_debug("mmccard: write to %llx", address);
+                            log_debug("mmccard: write to %llx", (int64_t)address);
                             if (mmc_wprot) {
                                 mmc_shiftreg = 0xff;
                                 mmc_state = MMC_IDLE;
@@ -215,7 +215,7 @@ void mmccard_load(char *fn)
     fseek(fp, 0, SEEK_END);
     mmc_size = ftell(fp);
     mmc_fp = fp;
-    log_debug("mmcard: %s loaded, size=%lld", fn, mmc_size);
+    log_debug("mmcard: %s loaded, size=%lld", fn, (int64_t)mmc_size);
 }
 
 void mmccard_eject(void)

--- a/src/musahi/m68kfpu.c
+++ b/src/musahi/m68kfpu.c
@@ -415,7 +415,7 @@ static fp_reg READ_EA_FPE(int ea)
             r.i = (uint64)(d1) << 32 | (uint64)(d2);
             break;
         }
-        default:    fatalerror("MC68040: READ_EA_FPE: unhandled mode %d, reg %d, at %08X\n", mode, reg, REG_PC);
+        default: r.i = 0; fatalerror("MC68040: READ_EA_FPE: unhandled mode %d, reg %d, at %08X\n", mode, reg, REG_PC);
     }
 
     return r;

--- a/src/vdfs.c
+++ b/src/vdfs.c
@@ -3450,9 +3450,9 @@ static bool copy_file(vdfs_entry *old_ent, vdfs_entry *new_ent)
 static bool copy_file(vdfs_entry *old_ent, vdfs_entry *new_ent)
 {
     bool res = false;
-    int old_fp = fopen(old_ent->host_path, "rb");
+    FILE *old_fp = fopen(old_ent->host_path, "rb");
     if (old_fp) {
-        int new_fp = fopen(new_ent->host_path, "wb");
+        FILE *new_fp = fopen(new_ent->host_path, "wb");
         if (new_fp) {
             res = true;
             int ch = getc(old_fp);

--- a/src/x86.c
+++ b/src/x86.c
@@ -1206,13 +1206,13 @@ void x86_exec()
         signed char offset;
         int tempws;
         uint32_t ea, templ;
-        int c,cycdiff;
+        int c; //cycdiff;
         int tempi;
 //        tubecycles+=(cycs<<2);
 //        printf("X86exec %i %i\n",tubecycles,cycs);
         while (tubecycles>0)
         {
-                cycdiff=tubecycles;
+//                cycdiff=tubecycles;
 //                old83=old82;
 //                old82=old8;
 //                old8=pc+(CS<<16);
@@ -3865,7 +3865,7 @@ void x86_exec()
                         ss=oldss;
                         ssegs=0;
                 }
-                cycdiff-=tubecycles;
+//                cycdiff-=tubecycles;
 
 x86ins++;
 //if (x86ins==65300000) x86output=1;


### PR DESCRIPTION
I fixed all of the warnings generated on macOS Ventura 13.2.1 with Apple clang version 14.0.0 (clang-1400.0.29.202).  

I also built on Linux gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0 and no warnings were generated there either.

I haven't built this on Windows.  Please can you let me know which compiler/dev environment you use on Windows so that I can set up the same?