### PR TITLE
Add support for the Watford Electronics ROM/RAM board.

### DIFF
--- a/b-em.cfg
+++ b/b-em.cfg
@@ -406,6 +406,20 @@ rom15=integra120
 rom14=basic2
 rom13=vdfs
 rom12=dfs09
+[model_27]
+name=BBC B w/1770 FDC + WE ROM/RAM
+fdc=acorn
+65c02=false
+b+=false
+master=false
+modela=false
+os01=false
+compact=false
+os=os12
+tube=none
+romsetup=weramrom
+rom15=basic2
+rom13=dfs226
 [disc]
 defaultwriteprotect=false
 scsienable=false

--- a/src/6502.c
+++ b/src/6502.c
@@ -745,11 +745,34 @@ static void write_fe34(int val)
 
 static void do_writemem(uint32_t addr, uint32_t val)
 {
-        int c;
+    int c;
+    static int watford_ram_bank = 14;
 
     addr &= 0xffff;
 
         writec[addr] = 31;
+
+        // Watford ROM/RAM board
+        if (!strcmp(models[curmodel].romsetup->name, "weramrom"))
+        {
+          if (addr >= 0xFF30 && addr <= 0xFF3F)
+          {
+            watford_ram_bank = addr - 0xFF30;
+            return;
+          }
+
+          if (addr >= 0x8000 && addr <= 0xBFFF)
+          {
+            int memtype = rom_slots[watford_ram_bank].swram ? 1 :2;
+            romsel = watford_ram_bank << 14;
+            if (memtype == 1)
+            {
+              uint8_t *base = rom + romsel - 0x8000;
+              *(base + addr) =  (uint8_t)val;
+            }
+            return;
+          }
+        }
 
         c = memstat[vis20k][addr >> 8];
         if (c == 1) {

--- a/src/mem.c
+++ b/src/mem.c
@@ -272,6 +272,25 @@ void mem_romsetup_master(void) {
     exit(1);
 }
 
+void mem_romsetup_weramrom(void) {
+    const char *sect = models[curmodel].cfgsect;
+    int slot;
+
+    load_os_rom(sect);
+    for (slot = 15; slot >= 0; slot--)
+        cfg_load_rom(slot, sect);
+
+    rom_slots[14].swram = 1;
+    rom_slots[7].swram = 1;
+    rom_slots[6].swram = 1;
+    rom_slots[5].swram = 1;
+    rom_slots[4].swram = 1;
+    rom_slots[3].swram = 1;
+    rom_slots[2].swram = 1;
+    rom_slots[1].swram = 1;
+    rom_slots[0].swram = 1;
+}
+
 int mem_findswram(int n) {
     int c;
 

--- a/src/mem.h
+++ b/src/mem.h
@@ -22,6 +22,7 @@ extern void mem_romsetup_swram(void);
 extern void mem_romsetup_bp128(void);
 extern void mem_romsetup_master(void);
 extern void mem_romsetup_compact(void);
+extern void mem_romsetup_weramrom(void);
 extern void mem_fillswram(void);
 extern int mem_findswram(int n);
 extern void mem_clearroms(void);

--- a/src/model.c
+++ b/src/model.c
@@ -40,14 +40,15 @@ static const char fdc_names[FDC_MAX][8] =
     "watford"
 };
 
-#define NUM_ROM_SETUP 5
+#define NUM_ROM_SETUP 6
 static rom_setup_t rom_setups[NUM_ROM_SETUP] =
 {
-    { "swram",   mem_romsetup_swram   },
-    { "os01",    mem_romsetup_os01    },
-    { "std",     mem_romsetup_std     },
-    { "bp128",   mem_romsetup_bp128   },
-    { "master",  mem_romsetup_master  }
+    { "swram",    mem_romsetup_swram    },
+    { "os01",     mem_romsetup_os01     },
+    { "std",      mem_romsetup_std      },
+    { "bp128",    mem_romsetup_bp128    },
+    { "master",   mem_romsetup_master   },
+    { "weramrom", mem_romsetup_weramrom }
 };
 
 /*

--- a/src/model.h
+++ b/src/model.h
@@ -18,7 +18,7 @@ typedef enum
 
 typedef struct
 {
-    char name[8];
+    char name[10];
     void (*func)(void);
 } rom_setup_t;
 


### PR DESCRIPTION
This small set of changes adds support for the Watford Electronics RAM/ROM board.  The board has 128K of DRAM and 16K SRAM on it along with ROM sockets.  The 128K of DRAM can be used as 8 SWR banks 0 through 7 or, using ROMs provided with the board, a 128K RAM disk or printer buffer.
The 16K SRAM is available as SWR bank 14.
Writing to the DRAM or SRAM is controlled by a latch controlled by writes to address &FF30 to &FF3F.
I added this to b-em with a new SWRAM configuration type of weramrom which configures the RAM banks, ROM slots and invokes the code to handle the latch and writes to &8000 to &BFFF.  Is this the right way to do it?
I've built and tested it on Linux, Windows and macOS.  Would it help if I included an image of the disk that comes with the board and contains the silicon file system and printer buffer ROMS?