### PR TITLE
sound: Poll SN76489 at 125 kHz

### DIFF
--- a/src/6502.c
+++ b/src/6502.c
@@ -235,6 +235,7 @@ static inline void polltime(int c)
     via_poll(&sysvia, c);
     via_poll(&uservia, c);
     video_poll(c, 1);
+    sound_poll(c);
     otherstuffcount -= c;
     if (motoron) {
         if (fdc_time) {
@@ -1057,7 +1058,6 @@ static void otherstuff_poll(void) {
     acia_poll(&sysacia);
     if (sound_music5000)
         music2000_poll();
-    sound_poll();
     if (!tapelcount) {
         tape_poll();
         tapelcount = tapellatch;

--- a/src/resid.cc
+++ b/src/resid.cc
@@ -51,7 +51,7 @@ void sid_init()
                 psid->sid->write(c,0);
                 
         if (!psid->sid->set_sampling_parameters((float)cycles_per_sec, method,
-                                                (float) FREQ_SO, 0.9*((float) FREQ_SO)/2.0))
+                                                (float) FREQ_SID, 0.9*((float) FREQ_SID)/2.0))
                                             {
   //                                                      printf("reSID failed!\n");
                                                 }
@@ -72,7 +72,7 @@ void sid_reset()
 void sid_settype(int resamp, int model)
 {
         sampling_method method=(resamp)?SAMPLE_RESAMPLE_INTERPOLATE:SAMPLE_INTERPOLATE;
-        if (!psid->sid->set_sampling_parameters((float)1000000, method,(float) FREQ_SO, 0.9*((float) FREQ_SO)/2.0))
+        if (!psid->sid->set_sampling_parameters((float)1000000, method,(float) FREQ_SID, 0.9*((float) FREQ_SID)/2.0))
         {
 //                rpclog("Change failed\n");
         }

--- a/src/sn76489.c
+++ b/src/sn76489.c
@@ -6,7 +6,7 @@
 #include "sn76489.h"
 #include "sound.h"
 #include "via.h"
-#include "uservia.h"
+#include "sysvia.h"
 
 uint8_t sn_freqhi[4], sn_freqlo[4];
 uint8_t sn_vol[4];
@@ -69,6 +69,10 @@ void sn_fillbuf(int16_t *buffer, int len)
 {
         int c, d;
         static int sidcount = 0;
+        uint8_t sdb_data;
+
+        if (sysvia_get_sn_data(&sdb_data))
+                sn_write(sdb_data);
 
         for (d = 0; d < len; d++)
         {
@@ -78,7 +82,7 @@ void sn_fillbuf(int16_t *buffer, int len)
                         if (sn_latch[c] > 256) buffer[d] += (int16_t) (snwaves[curwave][sn_stat[c]] * volslog[sn_vol[c]]);
                         else                   buffer[d] += (int16_t) (volslog[sn_vol[c]] * 127);
 
-                        sn_count[c] -= 8192;
+                        sn_count[c] -= 2048;
                         while ((int)sn_count[c] < 0  && sn_latch[c])
                         {
                                 sn_count[c] += sn_latch[c];
@@ -94,7 +98,7 @@ void sn_fillbuf(int16_t *buffer, int len)
                 }
                 else    buffer[d] += (((sn_shift & 1) ^ 1) * 127 * volslog[sn_vol[0]] * 2);
 
-                sn_count[0] -= 512;
+                sn_count[0] -= 128;
                 while ((int)sn_count[0] < 0 && sn_latch[0])
                 {
                         sn_count[0] += (sn_latch[0] * 2);
@@ -119,7 +123,7 @@ void sn_fillbuf(int16_t *buffer, int len)
 //                buffer[d] += (lpt_dac * 32);
 
                 sidcount++;
-                if (sidcount == 624)
+                if (sidcount == 2496)
                 {
                         sidcount = 0;
                         if (!sn_rect_dir)

--- a/src/sound.h
+++ b/src/sound.h
@@ -3,13 +3,14 @@
 
 /* Source frequencies in Hz */
 
-#define FREQ_SO  31250   // normal sound
+#define FREQ_SO  125000  // normal sound
+#define FREQ_SID 31250   // BeebSID
 #define FREQ_DD  44100   // disc drive noise
 #define FREQ_M5  46875   // music 5000
 
 /* Source buffer lengths in time samples */
 
-#define BUFLEN_SO 2000   //  64ms @ 31.25KHz  (must be multiple of 2)
+#define BUFLEN_SO 8000   //  64ms @ 125KHz    (must be multiple of 8)
 #define BUFLEN_DD 4410   // 100ms @ 44.1KHz
 #define BUFLEN_M5 1500   //  64ms @ 46.875KHz (must be multiple of 3)
 
@@ -20,6 +21,6 @@ extern bool sound_ddnoise, sound_tape;
 extern bool sound_music5000, sound_filter, sound_paula;
 
 void sound_init(void);
-void sound_poll(void);
+void sound_poll(int cycles);
 
 #endif

--- a/src/sysvia.c
+++ b/src/sysvia.c
@@ -93,9 +93,6 @@ static void sysvia_write_IC32(uint8_t val)
 
         sysvia_update_sdb();
 
-        if (!(IC32 & 1) && (oldIC32 & 1))
-           sn_write(sdbval);
-
         scrsize = ((IC32 & 0x10) ? 2 : 0) | ((IC32 & 0x20) ? 1 : 0);
 
     log_debug("sysvia: IC32=%02X", IC32);
@@ -193,4 +190,11 @@ void sysvia_loadstate(FILE *f)
 
         IC32=getc(f);
         scrsize=((IC32&16)?2:0)|((IC32&32)?1:0);
+}
+
+int sysvia_get_sn_data(uint8_t *data)
+{
+        *data = sdbval;
+
+        return !(IC32 & 1);
 }

--- a/src/sysvia.h
+++ b/src/sysvia.h
@@ -19,4 +19,6 @@ void sysvia_set_ca2(int level);
 void sysvia_set_cb1(int level);
 void sysvia_set_cb2(int level);
 
+int sysvia_get_sn_data(uint8_t *data);
+
 #endif


### PR DESCRIPTION
Polling the SN76489 at 125 kHz (the native "update" rate on real hardware, 4 MHz / 32) improves the audio quality of multi-voice sample playback, by significantly reducing the time spent in "in-between" states where not all voices have yet had their volumes updated.

As part of this, the handling of SN write is modified to a poll as part of the 125 kHz update routine. This allows multiple writes with the chip enable held active to be honoured (eg the Castlevania III music conversion).