### PR TITLE
CiscOS memory map changes

### DIFF
--- a/src/mc68000tube.h
+++ b/src/mc68000tube.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-#define MC68000_RAM_SIZE 0x3F0000
+#define MC68000_RAM_SIZE 0x800000
 #define MC68000_ROM_SIZE 0x8000
 
 extern bool tube_68000_init(void *rom);

--- a/src/model.h
+++ b/src/model.h
@@ -55,7 +55,12 @@ typedef struct
     int  speed_multiplier;
 } TUBE;
 
-#define NUM_TUBES 13
+#ifdef M68K
+# define NUM_TUBES 14
+#else
+# define NUM_TUBES 13
+#endif
+
 extern TUBE tubes[NUM_TUBES];
 
 extern int curmodel, curtube, oldmodel, selecttube;


### PR DESCRIPTION
CiscOS determines the amount of memory available by writing a known value to 0x00000000 and then checking every 1K (0x400) bytes for that value.  The original hardware presumably only decoded the address lines it needed for the installed memory causing the memory to be available at every multiple of the RAM size.