### PR TITLE
Add stopwatches feature to debugger.

### DIFF
--- a/src/6502.c
+++ b/src/6502.c
@@ -226,6 +226,7 @@ int output = 0;
 static int timetolive = 0;
 
 int cycles;
+uint64_t stopwatch;
 static int otherstuffcount = 0;
 int romsel;
 
@@ -237,6 +238,7 @@ static void polltime(int c)
     video_poll(c, 1);
     sound_poll(c);
     music5000_poll(c);
+    stopwatch += c;
     otherstuffcount -= c;
     if (motoron) {
         if (fdc_time) {
@@ -1032,6 +1034,7 @@ void m6502_reset(void)
         nmi = oldnmi = 0;
         output = 0;
         tubecycle = tubecycles = 0;
+        stopwatch = 0;
         log_debug("PC : %04X\n", pc);
 }
 

--- a/src/6502.h
+++ b/src/6502.h
@@ -5,7 +5,6 @@
 
 extern uint8_t a,x,y,s;
 extern uint16_t pc;
-extern uint_least32_t cycles_6502;
 
 extern PREG p;
 
@@ -23,6 +22,7 @@ extern int interrupt;
  */
 extern int nmi;
 
+extern uint64_t stopwatch;
 extern int romsel;
 extern uint8_t ram1k, ram4k, ram8k;
 

--- a/src/video.h
+++ b/src/video.h
@@ -17,6 +17,7 @@ extern int crtc_i;
 
 extern int hc, vc, sc;
 extern uint16_t ma;
+extern uint64_t stopwatch_vblank;
 
 /*Video ULA (VIDPROC)*/
 void videoula_write(uint16_t addr, uint8_t val);


### PR DESCRIPTION
I developed this addition for the B-Em debugger while trying to optimise a program. It adds a command which tells you how many host CPU cycles have elapsed between the last vertical blank or one or more user-defined defined points in time. There doesn't seem to be a way to do this at the moment, other than perhaps to process the trace output.

I'm open to feedback on the UX as it's very primitive.