### PR TITLE
Fix screenshots missing the bottom line of pixels

### DIFF
--- a/src/vidalleg.c
+++ b/src/vidalleg.c
@@ -260,7 +260,7 @@ static inline void save_screenshot(void)
     vid_savescrshot--;
     if (!vid_savescrshot) {
         int xsize = lastx - firstx;
-        int ysize = lasty - firsty;
+        int ysize = lasty - firsty + 1;
         ALLEGRO_BITMAP *scrshotb  = al_create_bitmap(xsize, ysize << 1);
         int c;
 


### PR DESCRIPTION
Screenshots created with the built-in feature are missing the bottom line of pixels. This PR changes the calculation of `ysize` in `save_screenshot` to match the one in `blit_screen`. This makes sense if `firsty` and `lasty` form an inclusive range.