### PR TITLE
Fix the sorting of speeds loaded from the configuration file

### DIFF
--- a/src/b-em.h
+++ b/src/b-em.h
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #include "compat_wrappers.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -172,7 +172,8 @@ static double main_calc_timer(int speed)
 
 static int main_speed_cmp(const void *va, const void *vb)
 {
-    return ((const emu_speed_t *)va)->multiplier - ((const emu_speed_t *)vb)->multiplier;
+    double res = ((const emu_speed_t *)va)->multiplier - ((const emu_speed_t *)vb)->multiplier;
+    return (int)round(res);
 }
 
 static void main_load_speeds(void)


### PR DESCRIPTION
When loading speeds from the configuration file, the result would be sorted incorrectly and the emulator would end up running at 150% speed by default on my computer at least.