### PR TITLE
NS32016: add T-bit trace trap support to permit single-stepping instructions

### DIFF
--- a/src/NS32016/32016.c
+++ b/src/NS32016/32016.c
@@ -3068,5 +3068,10 @@ void n32016_exec()
          }
       }
 #endif
+
+      if (T_FLAG)
+      {
+         GOTO_TRAP(TraceTrap);
+      }
    }
 }

--- a/src/NS32016/Trap.c
+++ b/src/NS32016/Trap.c
@@ -25,7 +25,8 @@ const char TrapText[TrapCount][40] =
    "Illegal SpecialWriting",
    "Illegal Writing Immediate",
    "Flag Instuction",
-   "Privileged Instruction"
+   "Privileged Instruction",
+   "Trace Trap"
 };
 
 void ShowTraps(void)
@@ -67,5 +68,6 @@ void n32016_dumpregs(const char* pMessage)
 
 void HandleTrap(void)
 {
+   T_FLAG = 0;
    n32016_dumpregs("HandleTrap() called");
 }

--- a/src/NS32016/Trap.h
+++ b/src/NS32016/Trap.h
@@ -15,10 +15,11 @@ enum TrapTypes
    IllegalWritingImmediate = BIT(10),
    FlagInstruction = BIT(11),
    PrivilegedInstruction = BIT(12),
+   TraceTrap = BIT(13),
 
 };
 
-#define TrapCount 13
+#define TrapCount 14
 extern uint32_t TrapFlags;
 #define CLEAR_TRAP() TrapFlags = 0
 


### PR DESCRIPTION
Add T-bit trace trap support to permit single-stepping instructions in a debugger.  Like with the actual NS32016 the T-bit does nothing until explicitly enabled.

I'm using an emulator derived from this in b-em to implement a gdbserver for NS32016, to test it out before deploying and testing against real hardware.  I had to add this for it to actually function since it's central to any debugger.  I realize none of your current targets would likely use it for anything, but since it doesn't do anything unless enabled it can't hurt, and it does make the emulation ever so slightly more complete.
